### PR TITLE
Fix[member]: 비밀번호 재설정 진행 과정 중 이메일 인증 검증 로직 추가 

### DIFF
--- a/backend/src/main/java/com/ai/lawyer/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ai/lawyer/domain/member/controller/MemberController.java
@@ -20,13 +20,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Slf4j
-@Tag(name = "Member", description = "회원 관리 API")
+@Tag(name = "회원 관리", description = "회원 관리 API")
 public class MemberController {
 
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
+    @Operation(summary = "01. 회원가입", description = "새로운 회원을 등록합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (중복 이메일/닉네임, 유효성 검증 실패)")
@@ -40,7 +40,7 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @Operation(summary = "02. 로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패 (존재하지 않는 회원, 비밀번호 불일치)")
@@ -55,7 +55,7 @@ public class MemberController {
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
+    @Operation(summary = "08. 로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그아웃 성공")
     })
@@ -76,7 +76,7 @@ public class MemberController {
     }
 
     @PostMapping("/refresh")
-    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
+    @Operation(summary = "04. 토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
@@ -98,7 +98,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/withdraw")
-    @Operation(summary = "회원탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다.")
+    @Operation(summary = "09. 회원탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원탈퇴 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
@@ -120,7 +120,7 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
+    @Operation(summary = "03. 내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
@@ -139,7 +139,7 @@ public class MemberController {
     }
 
     @PostMapping("/sendEmail")
-    @Operation(summary = "이메일 인증번호 전송", description = "로그인된 사용자는 자동으로 인증번호를 받고, 비로그인 사용자는 요청 바디의 loginId(이메일)로 인증번호를 받습니다.")
+    @Operation(summary = "05. 인증번호 전송", description = "로그인된 사용자는 자동으로 인증번호를 받고, 비로그인 사용자는 요청 바디의 loginId(이메일)로 인증번호를 받습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "이메일 전송 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (loginId 없음)")
@@ -198,7 +198,7 @@ public class MemberController {
     }
 
     @PostMapping("/verifyEmail")
-    @Operation(summary = "이메일 인증번호 검증", description = "로그인된 사용자는 자동으로 인증번호를 검증하고, 비로그인 사용자는 요청 바디의 loginId(이메일)와 함께 인증번호를 검증합니다.")
+    @Operation(summary = "06. 인증번호 검증", description = "로그인된 사용자는 자동으로 인증번호를 검증하고, 비로그인 사용자는 요청 바디의 loginId(이메일)와 함께 인증번호를 검증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "인증번호 검증 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (인증번호 불일치, loginId 없음)")
@@ -265,18 +265,63 @@ public class MemberController {
     // ===== 비밀번호 재설정 엔드포인트 =====
 
     @PostMapping("/password-reset/reset")
-    @Operation(summary = "비밀번호 재설정", description = "인증 토큰과 함께 새 비밀번호로 재설정합니다.")
+    @Operation(summary = "07. 비밀번호 재설정", description = "인증 토큰과 함께 새 비밀번호로 재설정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공"),
             @ApiResponse(responseCode = "400", description = "인증되지 않았거나 잘못된 요청")
     })
-    public ResponseEntity<PasswordResetResponse> resetPassword(@Valid @RequestBody ResetPasswordRequestDto request) {
-        log.info("비밀번호 재설정 요청: email={}", request.getLoginId());
+    public ResponseEntity<PasswordResetResponse> resetPassword(
+            @RequestBody ResetPasswordRequestDto request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
 
-        memberService.resetPassword(request.getLoginId(), request.getNewPassword(), request.getSuccess());
+        // 입력값 검증
+        if (request.getNewPassword() == null || request.getNewPassword().isBlank()) {
+            throw new IllegalArgumentException("새 비밀번호를 입력해주세요.");
+        }
+        if (request.getSuccess() == null) {
+            throw new IllegalArgumentException("인증 성공 여부가 필요합니다.");
+        }
 
-        log.info("비밀번호 재설정 성공: email={}", request.getLoginId());
-        return ResponseEntity.ok(PasswordResetResponse.success("비밀번호가 성공적으로 재설정되었습니다.", request.getLoginId()));
+        String loginId = null;
+
+        // 1. 로그인된 사용자인 경우 JWT 토큰에서 loginId 추출 (우선순위 1)
+        if (authentication != null && authentication.isAuthenticated() &&
+            !"anonymousUser".equals(authentication.getPrincipal())) {
+
+            // JWT 토큰에서 직접 loginid claim 추출
+            try {
+                String token = extractAccessTokenFromRequest(httpRequest);
+                if (token != null) {
+                    loginId = memberService.extractLoginIdFromToken(token);
+                    if (loginId != null) {
+                        log.info("JWT 토큰에서 loginId 추출 성공: {}", loginId);
+                    } else {
+                        log.warn("JWT 토큰에서 loginId 추출 실패");
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("JWT 토큰에서 loginId 추출 중 오류: {}", e.getMessage());
+            }
+        }
+
+        // 2. 비로그인 사용자인 경우 요청 바디에서 loginId 추출 (우선순위 2)
+        if (loginId == null) {
+            if (request.getLoginId() != null && !request.getLoginId().isBlank()) {
+                loginId = request.getLoginId();
+                log.info("요청 바디에서 loginId 추출 성공: {}", loginId);
+            } else {
+                log.error("로그인하지 않은 상태에서 요청 바디에 loginId가 없음");
+                throw new IllegalArgumentException("비밀번호를 재설정할 이메일 주소가 필요합니다. 로그인하거나 요청 바디에 loginId를 포함해주세요.");
+            }
+        }
+
+        log.info("비밀번호 재설정 요청: email={}", loginId);
+
+        memberService.resetPassword(loginId, request.getNewPassword(), request.getSuccess());
+
+        log.info("비밀번호 재설정 성공: email={}", loginId);
+        return ResponseEntity.ok(PasswordResetResponse.success("비밀번호가 성공적으로 재설정되었습니다.", loginId));
     }
 
     /**

--- a/backend/src/main/java/com/ai/lawyer/domain/member/dto/ResetPasswordRequestDto.java
+++ b/backend/src/main/java/com/ai/lawyer/domain/member/dto/ResetPasswordRequestDto.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ResetPasswordRequestDto {
-    @NotBlank(message = "이메일을 입력해주세요.")
     private String loginId;
 
     @NotBlank(message = "새 비밀번호를 입력해주세요.")

--- a/backend/src/main/java/com/ai/lawyer/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/ai/lawyer/domain/member/service/MemberService.java
@@ -141,8 +141,11 @@ public class MemberService {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        // 인증 성공 여부 확인
-        if (!Boolean.TRUE.equals(success)) {
+        // 클라이언트에서 전달한 success 값과 Redis의 인증 성공 여부를 모두 확인
+        boolean clientSuccess = Boolean.TRUE.equals(success);
+        boolean redisVerified = emailAuthService.isEmailVerified(loginId);
+
+        if (!clientSuccess || !redisVerified) {
             throw new IllegalArgumentException("이메일 인증을 완료해야 비밀번호를 재설정할 수 있습니다.");
         }
 
@@ -150,6 +153,9 @@ public class MemberService {
         String encodedPassword = passwordEncoder.encode(newPassword);
         member.updatePassword(encodedPassword);
         memberRepository.save(member);
+
+        // 인증 데이터 삭제 (비밀번호 재설정 완료 후)
+        emailAuthService.clearAuthData(loginId);
 
         // 기존 리프레시 토큰 삭제 (보안상 로그아웃 처리)
         tokenProvider.deleteRefreshToken(loginId);

--- a/backend/src/main/java/com/ai/lawyer/global/springDoc/SpringDocConfig.java
+++ b/backend/src/main/java/com/ai/lawyer/global/springDoc/SpringDocConfig.java
@@ -4,9 +4,18 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Configuration
 @OpenAPIDefinition(info = @Info(title = "AI Lawyer API", version = "beta", description = "AI 변호사 서비스 API 문서입니다."))
@@ -24,6 +33,7 @@ public class SpringDocConfig {
                 .group("Member API")
                 .pathsToMatch("/api/auth/**")
                 .packagesToScan("com.ai.lawyer.domain.member.controller")
+                .addOpenApiCustomizer(orderBySummaryNumber())
                 .build();
     }
 
@@ -52,5 +62,34 @@ public class SpringDocConfig {
                 .pathsToMatch("/api/**")
                 .packagesToScan("com.ai.lawyer.domain")
                 .build();
+    }
+
+    private OpenApiCustomizer orderBySummaryNumber() {
+        return openApi -> {
+            if (openApi.getPaths() == null) return;
+
+            Map<String, PathItem> sortedPaths = new LinkedHashMap<>();
+
+            // 정렬을 위해 summary 안에 있는 번호 추출
+            Pattern pattern = Pattern.compile("^(\\d+)\\..*");
+
+            openApi.getPaths().entrySet().stream()
+                    .sorted(Comparator.comparingInt(e -> {
+                        PathItem pathItem = e.getValue();
+                        // POST, GET, 등등 중 첫 번째 Operation의 summary 사용
+                        Operation op = pathItem.readOperations().stream().findFirst().orElse(null);
+                        if (op == null || op.getSummary() == null) return Integer.MAX_VALUE;
+
+                        Matcher matcher = pattern.matcher(op.getSummary());
+                        if (matcher.find()) {
+                            return Integer.parseInt(matcher.group(1));
+                        }
+                        return Integer.MAX_VALUE;
+                    }))
+                    .forEachOrdered(entry -> sortedPaths.put(entry.getKey(), entry.getValue()));
+
+            openApi.setPaths(new io.swagger.v3.oas.models.Paths());
+            sortedPaths.forEach(openApi.getPaths()::addPathItem);
+        };
     }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 비밀번호 재설정 컨트롤러의 loginid값을 필수에서 선택으로 변경
- 이메일 인증에 대한 성공 여부를 레디스에 저장해서 검증하는 로직 추가
- 스웨거 정렬 코드 추가

## 📝 참고 사항
- 리뷰어가 알면 좋을 내용
